### PR TITLE
Add pretrain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,6 @@ jobs:
       - name: "Install package"
         run: pip install .
       - name: "Install pytest"
-        run: pip instal pytest
+        run: pip install pytest
       - name: "Run tests"
         run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Run tests
+on: [push]
+jobs:
+  Run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: "Install package"
+        run: pip install .
+      - name: "Install pytest"
+        run: pip instal pytest
+      - name: "Run tests"
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Venv
+venv
+
+# Data
+*.jsonl
+
+# Models
+models/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ venv
 
 # Models
 models/
+
+# Python cache, eggs
+**/__pycache__
+**egg-info
+
+# Helper scripts
+prepare_data.py

--- a/README.md
+++ b/README.md
@@ -2,3 +2,55 @@
 
 A tool to pretrain neural network models before fine tuning on a
 give task.
+
+# Quickstart
+
+Install the package
+```
+git clone https://github.com/MantisAI/pretrain.git
+pip install .
+```
+
+Run pretrain
+```
+pretrain data.jsonl models/
+```
+
+You need data in a JSONL format with a `text` key
+
+# Pretrain CLI
+
+```
+Usage: pretrain [OPTIONS] DATA_PATH MODEL_PATH
+
+  data_path: pure text, one document per line model_path: path to save model
+  pretrained_model: name of pretrained model to use
+
+Arguments:
+  DATA_PATH   [required]
+  MODEL_PATH  [required]
+
+Options:
+  --pretrained-model TEXT         [default: distilbert-base-uncased]
+  --batch-size INTEGER            [default: 32]
+  --learning-rate FLOAT           [default: 1e-05]
+  --epochs INTEGER                [default: 5]
+  --mask-percentage FLOAT         [default: 0.15]
+  --dry-run / --no-dry-run        [default: no-dry-run]
+  --help                          Show this message and exit.
+```
+
+# Contribute
+
+Create and activate a virtualenv e.g.
+```
+python -m venv venv
+source venv/bin/activate
+```
+
+Install dependencies and package
+```
+pip install -r requirements.txt
+pip install -e .
+```
+

--- a/pretrain.py
+++ b/pretrain.py
@@ -1,0 +1,105 @@
+import random
+import json
+
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+from tqdm import tqdm
+import torch
+import typer
+
+
+def load_data(data_path):
+    data = []
+    with open(data_path) as f:
+        for line in f:
+            item = json.loads(line)
+            data.append(item["text"])
+    return data
+
+
+class Dataset(torch.utils.data.Dataset):
+    def __init__(self, data, tokenizer, mask_percentage=0.15):
+        self.data = data
+        self.tokenizer = tokenizer
+        self.mask_percentage = mask_percentage
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        inputs = self.tokenizer(self.data[idx], padding="max_length", truncation=True)
+        masked_input_ids = torch.tensor(
+            [
+                self.tokenizer.mask_token_id
+                if (random.random() < self.mask_percentage)
+                and (input_id != self.tokenizer.pad_token_id)
+                else input_id
+                for input_id in inputs["input_ids"]
+            ]
+        )
+        labels = torch.tensor(inputs["input_ids"])
+        return masked_input_ids, labels
+
+
+def pretrain(
+    data_path,
+    model_path,
+    pretrained_model="distilbert-base-uncased",
+    batch_size:int=32,
+    learning_rate:float=1e-5,
+    epochs:int=5,
+    dry_run:bool=False
+):
+    """
+    data_path: pure text, one document per line
+    model_path: path to save model
+    pretrained_model: name of pretrained model to use
+    """
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    
+    # load data
+    data = load_data(data_path)
+
+    # load tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(pretrained_model)
+
+    # pass to dataset and dataloader
+    dataset = Dataset(data, tokenizer)
+    dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+    # load model to train
+    model = AutoModelForMaskedLM.from_pretrained(pretrained_model)
+    model.to(device)
+
+    # criterion, optimizer
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=learning_rate)
+
+    # torch training loop
+    for epoch in range(epochs):
+        batches = tqdm(dataloader, desc=f"Epoch {epoch+1}/{epochs}")
+        for batch in batches:
+            inputs, labels = batch[0].to(device), batch[1].to(device)
+
+            optimizer.zero_grad()
+
+            outputs = model(inputs)
+            preds = torch.transpose(outputs.logits, 2, 1)
+
+            loss = criterion(preds, labels)
+            loss.backward()
+
+            optimizer.step()
+
+            batches.set_postfix({"loss": loss.item()})
+
+            if dry_run:
+                break
+        
+        if dry_run:
+            break 
+
+    # save model
+    model.save_pretrained(model_path)
+
+if __name__ == "__main__":
+    typer.run(pretrain)

--- a/pretrain.py
+++ b/pretrain.py
@@ -7,6 +7,8 @@ import torch
 import typer
 
 
+app = typer.Typer()
+
 def load_data(data_path):
     data = []
     with open(data_path) as f:
@@ -40,6 +42,7 @@ class Dataset(torch.utils.data.Dataset):
         return masked_input_ids, labels
 
 
+@app.command()
 def pretrain(
     data_path,
     model_path,
@@ -47,6 +50,7 @@ def pretrain(
     batch_size:int=32,
     learning_rate:float=1e-5,
     epochs:int=5,
+    mask_percentage:float=0.15,
     dry_run:bool=False
 ):
     """
@@ -63,7 +67,7 @@ def pretrain(
     tokenizer = AutoTokenizer.from_pretrained(pretrained_model)
 
     # pass to dataset and dataloader
-    dataset = Dataset(data, tokenizer)
+    dataset = Dataset(data, tokenizer, mask_percentage)
     dataloader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
 
     # load model to train
@@ -102,4 +106,4 @@ def pretrain(
     model.save_pretrained(model_path)
 
 if __name__ == "__main__":
-    typer.run(pretrain)
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+transformers==4.17.0
+torch==1.11.0
+datasets==2.0.0
+black==22.1.0
+typer==0.4.0
+tqdm==4.63.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,28 @@
+[metadata]
+name = pretrain
+version = 0.0.1
+author = Nick Sorros
+author_email = nick@mantisnlp.com
+description = A tool to pretrain neural nets
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/MantisAI/pretrain.git
+project_urls =
+    Bug Tracker = https://github.com/MantisAI/pretrain/issues
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+
+[options]
+packages = find:
+install_requires = 
+    transformers
+    torch
+    tqdm
+    typer
+python_requires = >=3.6
+
+[options.entry_points]
+console_scripts =
+    pretrain = pretrain:app

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     torch
     tqdm
     typer
+    click < 8.1.0 # https://github.com/tiangolo/typer/issues/377 
 python_requires = >=3.6
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pretrain
-version = 0.0.1
+version = 0.1.0
 author = Nick Sorros
 author_email = nick@mantisnlp.com
 description = A tool to pretrain neural nets

--- a/test_pretrain.py
+++ b/test_pretrain.py
@@ -1,0 +1,29 @@
+import json
+import os
+
+import pytest
+
+from pretrain import pretrain
+
+
+@pytest.fixture
+def data_path(tmp_path):
+    data_path = os.path.join(tmp_path, "data.jsonl")
+
+    data = [
+        "This is the first test sentence",
+        "Use that data to test pretrain"
+    ] * 5
+    with open(data_path, "w") as f:
+        for text in data:
+            f.write(json.dumps({"text": text})+"\n")
+    return data_path
+
+@pytest.fixture
+def model_path(tmp_path):
+    model_path = os.path.join(tmp_path, "models")
+    return model_path
+
+def test_pretrain(data_path, model_path):
+    pretrain(data_path, model_path, dry_run=True)
+    assert os.path.exists(os.path.join(model_path, "config.json"))


### PR DESCRIPTION
The goal is to create a CLI tool and Python class to make it easier to pretrain models in the future. So for Kaggle and future clients we can use this library to easily pretrain models.

We care about masked language modelling (instead of causal language modelling) and also not about sentence prediction at this point but we can extend to those in the future.

I am implementing the training loop instead of using a Trainer to have more flexibility to tweak this to our needs. I am also thinking that we might want to pretrain general neural nets not only transformers.